### PR TITLE
Fix pin mapping for display matrix to use the MCU pins rather than the (incorrect) edge connector pins.

### DIFF
--- a/inc/drivers/MicroBitMatrixMaps.h
+++ b/inc/drivers/MicroBitMatrixMaps.h
@@ -70,8 +70,8 @@ struct MatrixMap
  */
 #define MICROBIT_DISPLAY_WIDTH                  5
 #define MICROBIT_DISPLAY_HEIGHT                 5
-#define MICROBIT_DISPLAY_ROW1                   P13
-#define MICROBIT_DISPLAY_COL1                   P4
+#define MICROBIT_DISPLAY_ROW1                   P0_13
+#define MICROBIT_DISPLAY_COL1                   P0_4
 
 
 #if MICROBIT_DISPLAY_TYPE == MICROBUG_REFERENCE_DEVICE


### PR DESCRIPTION
Before this change, using the MicroBitDisplay object resulted in garbage on the physical display. This is because the P13 and P4 macros refer to pin 13 and pin 4 on the edge connector of the MicroBit. We should be using the P0_13 and P0_4 macros - these refer to the MCU pins, which is what the display is connected to.